### PR TITLE
Update regex patterns for Director's Edition & Collector's Cut

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -390,7 +390,7 @@ export const handlers: Handler[] = [
   },
   {
     field: 'editions',
-    pattern: /\bExtended[\.\s\-\+_\/(),]Director'?s\b/i,
+    pattern: /\bExtended[\.\s\-\+_\/(),]Director\W?s\b/i,
     transform: toValueSet("Director's Cut"),
     keepMatching: true,
     remove: true
@@ -412,14 +412,14 @@ export const handlers: Handler[] = [
   },
   {
     field: 'editions',
-    pattern: /\bDirector'?s.?Cut\b/i,
+    pattern: /\bDirector\W?s.?Cut\b/i,
     transform: toValueSet("Director's Cut"),
     keepMatching: true,
     remove: true
   },
   {
     field: 'editions',
-    pattern: /\bCollector'?s\b/i,
+    pattern: /\bCollector\W?s\b/i,
     transform: toValueSet("Collector's Edition"),
     keepMatching: true,
     remove: true

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -468,6 +468,14 @@ export const handlers: Handler[] = [
     keepMatching: true,
     remove: true
   },
+  {
+    field: 'editions',
+    pattern: /\bDC\b/,
+    transform: toValueSet("Director's Cut"),
+    keepMatching: true,
+    remove: true,
+    skipIfBefore: ['year']
+  },
 
   // Release Types handlers (lines 608-623 in handlers.go)
   {


### PR DESCRIPTION
Make the Director's Cut and Collector's Edition patterns accept any non-alphanumeric character in the place of an apostrophe. Accounts for spaces ("director s cut") and other unconventional naming quirks.

Add handler to match "DC" as Director's Cut. This is a common naming convention.