### PR TITLE
feat: parse XVID 3-digit season/episode scheme (Show.103 → S01E03)

### DIFF
--- a/src/__tests__/episodes.test.ts
+++ b/src/__tests__/episodes.test.ts
@@ -1312,3 +1312,78 @@ describe('Episode Detection Tests', () => {
     expect(result.episodes).toBeUndefined();
   });
 });
+
+describe('XVID 3-digit season/episode scheme', () => {
+  test('parses the 3-digit scheme as season + episode', () => {
+    const result = parseTorrentTitle('Yes.Dear.103.dsr.xvid-saints.avi');
+    expect(result.seasons).toEqual([1]);
+    expect(result.episodes).toEqual([3]);
+    expect(result.title).toEqual('Yes Dear');
+  });
+
+  test('parses the 3-digit scheme with an episode title in the name', () => {
+    const result = parseTorrentTitle(
+      "Yes.Dear.106.Gregs.Big.Day.DSRip.XviD-SAiNT.avi"
+    );
+    expect(result.seasons).toEqual([1]);
+    expect(result.episodes).toEqual([6]);
+    expect(result.title).toEqual('Yes Dear');
+  });
+
+  test('parses season 3 episodes (301 = S03E01)', () => {
+    const result = parseTorrentTitle(
+      'Yes.Dear.301.Spanks.But.No.Spanks.SDTV.avi'
+    );
+    expect(result.seasons).toEqual([3]);
+    expect(result.episodes).toEqual([1]);
+  });
+
+  test('parses two-digit episodes (110 = S01E10)', () => {
+    const result = parseTorrentTitle(
+      'Yes.Dear.110.Talk.Time.DSRip.XviD-SAiNT.avi'
+    );
+    expect(result.seasons).toEqual([1]);
+    expect(result.episodes).toEqual([10]);
+  });
+
+  test('parses late seasons (615 = S06E15)', () => {
+    const result = parseTorrentTitle(
+      'Yes.Dear.615.Should.I.Bring.A.Jacket.avi'
+    );
+    expect(result.seasons).toEqual([6]);
+    expect(result.episodes).toEqual([15]);
+  });
+
+  test('does not disturb structured SxxExx markers', () => {
+    const result = parseTorrentTitle(
+      'The Simpsons S28E21 720p HDTV x264-AVS'
+    );
+    expect(result.seasons).toEqual([28]);
+    expect(result.episodes).toEqual([21]);
+  });
+
+  test('does not parse codec numbers (H.264 / H.265) as episodes', () => {
+    const result = parseTorrentTitle('Show.103.H.264.DSRip.avi');
+    expect(result.seasons).toEqual([1]);
+    expect(result.episodes).toEqual([3]);
+  });
+
+  test('does not parse years or resolutions as episodes', () => {
+    const result = parseTorrentTitle('Movie.2019.1080p.BluRay.x264-GROUP');
+    expect(result.episodes).toBeUndefined();
+  });
+
+  test('does not parse 100/200 (episode 0) as episodes', () => {
+    const result = parseTorrentTitle('Show.100.avi');
+    expect(result.seasons).toBeUndefined();
+    expect(result.episodes).toBeUndefined();
+  });
+
+  test('does not parse season packs (S01-S06) as episodes', () => {
+    const result = parseTorrentTitle(
+      'Yes.Dear.S01-S06.DVDRIP.480P.XVID.MPEG.2.0'
+    );
+    expect(result.seasons).toEqual(intRange(1, 6));
+    expect(result.episodes).toBeUndefined();
+  });
+});

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1891,6 +1891,80 @@ export const handlers: Handler[] = [
   },
   {
     field: 'episodes',
+    // XVID-era 3-digit scheme: "Show.103.Episode.Name.avi" is S01E03,
+    // "Show.301.Episode.Name.avi" is S03E01, "Show.110.avi" is S01E10.
+    // Leading digit(s) = season (1-9), trailing two digits = episode (01-99).
+    // Runs late so structured markers (S01E03, ep, Cap., ...) win first; the
+    // 264/265 codec handler above takes precedence for those values. Bare
+    // numbers in absolute-episode conventions ("- 107 -", "523 23"), event
+    // numbers ("UFC.218.PPV") and movie-title numbers ("Crime.101.2026") are
+    // explicitly excluded.
+    pattern: /(?<=^|[\W_])([1-9]\d{2})(?=\W|$)/i,
+    validateMatch: (input: string, idxs: number[]): boolean => {
+      const before = input.substring(0, idxs[0]);
+      const after = input.substring(idxs[1]);
+      // Codec numbers ("H.264", "H.265") must not become episodes.
+      if (/[hx][ .]?$/i.test(before)) {
+        return false;
+      }
+      // Absolute-episode conventions use hyphen dividers ("- 107 -").
+      if (/- ?$/i.test(before) || /^ ?- ?/i.test(after)) {
+        return false;
+      }
+      // Bracket/slash contexts (anime ranges "[166-192]", par2 "003/101").
+      if (/[(\[/]$/.test(before) || /^[)\]\/]/.test(after)) {
+        return false;
+      }
+      // A number followed by another number is not an episode ("523 23").
+      if (/^\W*\d/.test(after)) {
+        return false;
+      }
+      // Event numbers ("UFC.218.PPV").
+      if (/^\W*ppv\b/i.test(after)) {
+        return false;
+      }
+      // "100", "200", ... would be episode 0, which is invalid.
+      const v = Number(input.substring(idxs[2], idxs[3]));
+      return Number.isFinite(v) && v % 100 >= 1;
+    },
+    remove: true,
+    transform: (title, m, result) => {
+      // A year right after the number marks a movie title ("Crime.101.2026").
+      const ym = result.get('year');
+      if (ym !== undefined && ym.mIndex > m.mIndex) {
+        m.value = null;
+        return;
+      }
+      // Event numbers ("UFC.218.PPV"): the ppv handler already consumed the
+      // marker from the title, so check the parsed field instead.
+      const pm = result.get('ppv');
+      if (pm !== undefined && pm.mIndex > m.mIndex) {
+        m.value = null;
+        return;
+      }
+      const v = Number(m.value);
+      const season = Math.floor(v / 100);
+      const episode = v % 100;
+      const sm = result.get('seasons');
+      if (sm) {
+        // An explicit season marker wins; only fill in when absent.
+        if (sm.value === null) {
+          sm.value = [season];
+        }
+      } else {
+        result.set('seasons', {
+          mIndex: m.mIndex,
+          mValue: m.mValue,
+          value: [season],
+          remove: false,
+          processed: false
+        });
+      }
+      m.value = [episode];
+    }
+  },
+  {
+    field: 'episodes',
     pattern: /(?:\W|^)(?:\d+)?(?:e|ep)(\d{1,3})(?:\W|$)/i,
     transform: toIntArray(),
     remove: true


### PR DESCRIPTION
## What

Adds a late-running episodes handler for the classic XVID-era naming where season+episode is a single 3-digit number:

| Input | Result |
|---|---|
| `Yes.Dear.103.dsr.xvid-saints.avi` | S01E03, title "Yes Dear" |
| `Yes.Dear.106.Gregs.Big.Day.DSRip.XviD-SAiNT.avi` | S01E06 |
| `Yes.Dear.301.Spanks.But.No.Spanks.SDTV.avi` | S03E01 |
| `Yes.Dear.110.Talk.Time.DSRip.XviD-SAiNT.avi` | S01E10 |

The handler also fills in the `seasons` field when no explicit season marker is present, and strips the digits from the title (`remove: true`).

## Why

Old shows on NZB indexers often exist only as DVD/DSRip XVID season packs with this naming. Downstream consumers (AIOStreams' file selection inside season packs, see [Viren070/AIOStreams#1162](https://github.com/Viren070/AIOStreams/issues/1162)) rely on parsed `season`/`episodes` to pick the right file; without them every episode resolves to an arbitrary file.

## Design / false-positive guards

The handler runs late in the episodes batch so structured markers (S01E03, ep, Cap., …) win first. The 264/265 codec handler above takes precedence for those values. A `validateMatch` + transform reject:

- codec numbers (`H.264` / `H.265`, and `x264`/`x265` via the word-boundary lookbehind)
- absolute-episode conventions (`"- 107 -"`, `"523 23"`) — left to the existing fallback handler
- bracket/slash contexts (anime ranges `[166-192TV]`, par2 `(003/101)`)
- numbers followed by another number (`"523 23"`)
- PPV event numbers (`UFC.218.PPV` — the `ppv` feature handler consumes the marker first, so the check reads the parsed `ppv` field)
- movie-title numbers followed by a year (`Crime.101.2026` — year handler removes the year from the title, so the check reads the parsed `year` field)
- `100`/`200`-style values that would yield episode 0

## Ambiguity note

`110` is parsed as S01E10 (season = leading digit, episode = trailing two digits, seasons 1–9 only). This matches the convention used by the classic `parse-torrent-name` library. The 3-digit scheme is inherently ambiguous for shows with 10+ seasons; restricting to `[1-9]`-led values keeps the common case correct.

## Tests

10 new tests in `episodes.test.ts` covering the scheme, the guards above, and the exact filenames from AIOStreams#1162. Full suite: 1253 passed, 0 failed.

Closes #53